### PR TITLE
refactor: Update import paths to reflect repository name change

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,6 @@ VIPPS_MSN=your-merchant-serial-number
 VIPPS_TEST_MODE=true
 
 # Webhook Configuration
-VIPPS_WEBHOOK_SECRET_KEY=your-webhook-secret-key
 # For testing purposes, you can use ngrok to expose your local server
 # to the internet. Replace <PUBLICLY_ACCESSABLE> with the ngrok URL.
 # Example: ngrok http 8080

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Vipps MobilePay SDK for Go
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/gkhaavik/vipps-mobilepay-sdk.svg)](https://pkg.go.dev/github.com/gkhaavik/vipps-mobilepay-sdk)
-[![Go Report Card](https://goreportcard.com/badge/github.com/gkhaavik/vipps-mobilepay-sdk)](https://goreportcard.com/report/github.com/gkhaavik/vipps-mobilepay-sdk)
-[![License](https://img.shields.io/github/license/gkhaavik/vipps-mobilepay-sdk)](LICENSE)
+[![Go Reference](https://pkg.go.dev/badge/github.com/zenfulcode/vipps-mobilepay-sdk.svg)](https://pkg.go.dev/github.com/zenfulcode/vipps-mobilepay-sdk)
+[![Go Report Card](https://goreportcard.com/badge/github.com/zenfulcode/vipps-mobilepay-sdk)](https://goreportcard.com/report/github.com/zenfulcode/vipps-mobilepay-sdk)
+[![License](https://img.shields.io/github/license/zenfulcode/vipps-mobilepay-sdk)](LICENSE)
 
 A comprehensive Go SDK for the Vipps MobilePay ePayment API. This SDK allows you to easily integrate Vipps MobilePay payments into your Go applications.
 
@@ -19,7 +19,7 @@ A comprehensive Go SDK for the Vipps MobilePay ePayment API. This SDK allows you
 ## Installation
 
 ```bash
-go get github.com/gkhaavik/vipps-mobilepay-sdk
+go get github.com/zenfulcode/vipps-mobilepay-sdk
 ```
 
 ## Quick Start
@@ -31,8 +31,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/gkhaavik/vipps-mobilepay-sdk/pkg/client"
-	"github.com/gkhaavik/vipps-mobilepay-sdk/pkg/models"
+	"github.com/zenfulcode/vipps-mobilepay-sdk/pkg/client"
+	"github.com/zenfulcode/vipps-mobilepay-sdk/pkg/models"
 	"github.com/google/uuid"
 )
 

--- a/examples/payment/main.go
+++ b/examples/payment/main.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"time"
 
-	"github.com/gkhaavik/vipps-mobilepay-sdk/pkg/client"
-	"github.com/gkhaavik/vipps-mobilepay-sdk/pkg/models"
-	"github.com/gkhaavik/vipps-mobilepay-sdk/pkg/utils"
 	"github.com/google/uuid"
+	"github.com/zenfulcode/vipps-mobilepay-sdk/pkg/client"
+	"github.com/zenfulcode/vipps-mobilepay-sdk/pkg/models"
+	"github.com/zenfulcode/vipps-mobilepay-sdk/pkg/utils"
 )
 
 func main() {

--- a/examples/webhook/main.go
+++ b/examples/webhook/main.go
@@ -8,10 +8,10 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/gkhaavik/vipps-mobilepay-sdk/pkg/client"
-	"github.com/gkhaavik/vipps-mobilepay-sdk/pkg/models"
-	"github.com/gkhaavik/vipps-mobilepay-sdk/pkg/utils"
-	"github.com/gkhaavik/vipps-mobilepay-sdk/pkg/webhooks"
+	"github.com/zenfulcode/vipps-mobilepay-sdk/pkg/client"
+	"github.com/zenfulcode/vipps-mobilepay-sdk/pkg/models"
+	"github.com/zenfulcode/vipps-mobilepay-sdk/pkg/utils"
+	"github.com/zenfulcode/vipps-mobilepay-sdk/pkg/webhooks"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gkhaavik/vipps-mobilepay-sdk
+module github.com/zenfulcode/vipps-mobilepay-sdk
 
 go 1.21
 

--- a/pkg/client/payment.go
+++ b/pkg/client/payment.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/gkhaavik/vipps-mobilepay-sdk/pkg/models"
 	"github.com/google/uuid"
+	"github.com/zenfulcode/vipps-mobilepay-sdk/pkg/models"
 )
 
 // Payment handles all payment-related API calls

--- a/pkg/client/webhook.go
+++ b/pkg/client/webhook.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gkhaavik/vipps-mobilepay-sdk/pkg/models"
+	"github.com/zenfulcode/vipps-mobilepay-sdk/pkg/models"
 )
 
 // Webhook handles all webhook-related API calls

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/gkhaavik/vipps-mobilepay-sdk/pkg/client"
+	"github.com/zenfulcode/vipps-mobilepay-sdk/pkg/client"
 )
 
 // DefaultEnvFile is the default path to the .env file

--- a/pkg/webhooks/handler.go
+++ b/pkg/webhooks/handler.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gkhaavik/vipps-mobilepay-sdk/pkg/models"
+	"github.com/zenfulcode/vipps-mobilepay-sdk/pkg/models"
 )
 
 // Handler processes webhook events from Vipps MobilePay
@@ -181,6 +181,7 @@ func (r *Router) HandleDefault(handler EventProcessor) {
 
 // Process routes an event to the appropriate handler
 func (r *Router) Process(event *models.WebhookEvent) error {
+	fmt.Println("Processing event:", event.Name)
 	if handler, ok := r.handlers[event.Name]; ok {
 		return handler(event)
 	}


### PR DESCRIPTION
This pull request updates the repository's module path and all associated imports to reflect a new GitHub organization, `zenfulcode`, instead of `gkhaavik`. Additionally, it includes a minor enhancement to the webhook event processing logic.

### Repository migration updates:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R1): Changed the module path from `github.com/gkhaavik/vipps-mobilepay-sdk` to `github.com/zenfulcode/vipps-mobilepay-sdk`.
* Multiple files (`README.md`, `examples/payment/main.go`, `examples/webhook/main.go`, `pkg/client/payment.go`, `pkg/client/webhook.go`, `pkg/utils/config.go`, `pkg/webhooks/handler.go`): Updated all import paths to use `github.com/zenfulcode/vipps-mobilepay-sdk` instead of `github.com/gkhaavik/vipps-mobilepay-sdk`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R35) [[2]](diffhunk://#diff-b89d15ee50b735cec1e786e45d733b3def364f22c981d35825be5256bddd4836L8-R11) [[3]](diffhunk://#diff-f07b8fa8105c425d26b6552eca0303cb78086b55809da9c14b4e061446816fe6L11-R14) [[4]](diffhunk://#diff-e691fcafb5cb3f9a0d20373f3d74e695d8553b3c67f1397e878a5e261e255d11L9-R10) [[5]](diffhunk://#diff-0d9bb52d4a995ca0f4d7bba449911f12b28cfa8d3bc1ed08b26a5b42762e6db4L8-R8) [[6]](diffhunk://#diff-969580f0a75d8a4f220e2d6afb466dfcc523ffee1c907491a4fa17a2312d8658L8-R8) [[7]](diffhunk://#diff-327581f6f6a68d87648d2cd40b09f22d879cf2b62eddf4eeccb29f6cb22a4215L14-R14)

### Minor enhancements:

* [`pkg/webhooks/handler.go`](diffhunk://#diff-327581f6f6a68d87648d2cd40b09f22d879cf2b62eddf4eeccb29f6cb22a4215R184): Added a `fmt.Println` statement to log the name of the webhook event being processed for better debugging and visibility.